### PR TITLE
Base64 decoding via atob

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,12 @@
 # OS generated files and folders
 .DS_Store
 npm-debug.log
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -8,12 +8,3 @@
 # OS generated files and folders
 .DS_Store
 npm-debug.log
-
-# IDEs and editors
-/.idea
-.project
-.classpath
-.c9/
-*.launch
-.settings/
-*.sublime-workspace

--- a/lib/passkontrolle.js
+++ b/lib/passkontrolle.js
@@ -4,6 +4,17 @@ const uuid = require('uuidv4');
 
 const passkontrolle = {};
 
+passkontrolle.base64Decode = function(str) {
+    if (typeof Buffer !== 'undefined') {
+        return new Buffer(str, 'base64').toString('utf8');
+    }
+
+    // from https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding
+    return decodeURIComponent(atob(str).split("").map(function (c) {
+        return "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2);
+    }).join(""));
+};
+
 passkontrolle.getToken = function (url, regex) {
   if (!url) {
     throw new Error('Url is missing.');
@@ -56,7 +67,7 @@ passkontrolle.getPayloadFromIdToken = function (token) {
     // problems with unicode characters in the token's payload. Hence we
     // decided to go with Buffer, as this works flawlessly.
     const bodyBase64 = bodyBase64Url.replace(/-/g, '+').replace(/_/g, '/'),
-          bodyDecoded = new Buffer(bodyBase64, 'base64').toString('utf8');
+          bodyDecoded = passkontrolle.base64Decode(bodyBase64);
 
     payload = JSON.parse(bodyDecoded);
   } catch (ex) {

--- a/lib/passkontrolle.js
+++ b/lib/passkontrolle.js
@@ -4,15 +4,20 @@ const uuid = require('uuidv4');
 
 const passkontrolle = {};
 
-passkontrolle.base64Decode = function(str) {
-    if (typeof Buffer !== 'undefined') {
-        return new Buffer(str, 'base64').toString('utf8');
-    }
+passkontrolle.base64Decode = function (encodedString) {
+  if (!encodedString) {
+    throw new Error('Encoded string is missing.');
+  }
 
-    // from https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding
-    return decodeURIComponent(atob(str).split("").map(function (c) {
-        return "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2);
-    }).join(""));
+  if (typeof Buffer !== 'undefined') {
+    return new Buffer(encodedString, 'base64').toString('utf8');
+  }
+
+  // from https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding
+  return decodeURIComponent(atob(encodedString).split('').map(decodedChar => {
+    const urlEncodedCharCode = ('00' + decodedChar.charCodeAt(0).toString(16)).slice(-2);
+    return `%${urlEncodedCharCode}`;
+  }).join(''));
 };
 
 passkontrolle.getToken = function (url, regex) {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     {
       "name": "Matthias Wagler",
       "email": "matthias.wagler@thenativeweb.io"
+    },
+    {
+      "name": "Christoph Stickel",
+      "email": "christoph@neochic.de"
     }
   ],
   "main": "dist/passkontrolle.js",


### PR DESCRIPTION
Readded Base64 decoding via atob for browser environments, however kept the Buffer solution for NodeJS Environments to stay compatible. This makes the buffer polyfill needless.
Checked that unicode characters do work in both cases (for Browser and Node environments).
The change is especially important because in Angular-CLI 6 they removed the automatic adding of node polyfills.
https://github.com/angular/angular-cli/issues/9827#issuecomment-369578814